### PR TITLE
Fix encoding of the LOCAL_ONE consistency level.

### DIFF
--- a/cql-binary-protocol-v2.spec
+++ b/cql-binary-protocol-v2.spec
@@ -220,7 +220,7 @@ Table of Contents
                      0x0007    EACH_QUORUM
                      0x0008    SERIAL
                      0x0009    LOCAL_SERIAL
-                     0x0010    LOCAL_ONE
+                     0x000A    LOCAL_ONE
 
     [string map]      A [short] n, followed by n pair <k><v> where <k> and <v>
                       are [string].

--- a/src/Database/CQL/Protocol/Codec.hs
+++ b/src/Database/CQL/Protocol/Codec.hs
@@ -236,7 +236,7 @@ instance Encoding Consistency where
     encode EachQuorum  = encode (0x07 :: Word16)
     encode Serial      = encode (0x08 :: Word16)
     encode LocalSerial = encode (0x09 :: Word16)
-    encode LocalOne    = encode (0x10 :: Word16)
+    encode LocalOne    = encode (0x0A :: Word16)
 
 instance Decoding Consistency where
     decode = decode >>= mapCode


### PR DESCRIPTION
It seems to have been an error in the spec. See https://github.com/apache/cassandra/commit/09c7dee2554f6732505e603b16127a2c0b426d49
