### PR TITLE
Constrain batch queries to type 'W'.

### DIFF
--- a/src/Database/CQL/Protocol/Request.hs
+++ b/src/Database/CQL/Protocol/Request.hs
@@ -201,12 +201,12 @@ instance Encoding BatchType where
 
 data BatchQuery where
     BatchQuery :: (Show a, Tuple a, Tuple b)
-               => !(QueryString k a b)
+               => !(QueryString W a b)
                -> !a
                -> BatchQuery
 
     BatchPrepared :: (Show a, Tuple a, Tuple b)
-                  => !(QueryId k a b)
+                  => !(QueryId W a b)
                   -> !a
                   -> BatchQuery
 


### PR DESCRIPTION
Batch queries may only contain DML statements (insert/update/delete) which corresponds to type `W`. cf [CQL Spec v2](https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v2.spec#L347).
