### PR TITLE
Allow cas operations

### DIFF
--- a/src/Database/CQL/Protocol/Response.hs
+++ b/src/Database/CQL/Protocol/Response.hs
@@ -218,7 +218,10 @@ decodeResult v = decodeInt >>= go
         m <- decodeMetaData
         n <- decodeInt
         let c = untag (count :: Tagged b Int)
-        unless (columnCount m == fromIntegral c) $
+        let trans = case (columnSpecs m) of
+              (cs:_) -> columnName cs == "[applied]"
+              _      -> False
+        unless (trans || columnCount m == fromIntegral c) $
             fail $ "column count: "
                 ++ show (columnCount m)
                 ++ " =/= "


### PR DESCRIPTION
**Problem:**
CAS operations do not always return the same number of columns. It depends on whether the operation succeeded or not.

**Example:**
INSERT INTO users (userId, name) VALUES ("foo", "bar") IF NOT EXISTS;
If this operation is successful the row result will have 1 boolean column.

| [applied] |
|--------------|
| True        |

If it fails then the row result will have 3 columns

| [applied] | userId | name |
|--------------|-----------|---------|
| False       | "foo"   | "bar"  |

**Solution:**
check if first column name in row result is [applied] then if it is ignore the column count.

This way you can do something like this

```
trans :: (MonadClient m, CQL.Tuple a, RunQ q) => q CQL.W a (Identity Bool) -> CQL.QueryParams a -> m Bool
trans q p = do
  r <- runQ q p
  case r of
    CQL.RsResult _ (CQL.RowsResult _ ((Identity b):_)) -> return b
    _                                                  -> throwM UnexpectedResponse
```