### PR TITLE
Add support for UDTs to collections

### DIFF
--- a/src/Database/CQL/Protocol/Codec.hs
+++ b/src/Database/CQL/Protocol/Codec.hs
@@ -432,19 +432,19 @@ decodePagingState = liftM PagingState <$> decodeBytes
 putValue :: Version -> Putter Value
 putValue V3 (CqlList x)        = toBytes 4 $ do
     encodeInt (fromIntegral (length x))
-    mapM_ (toBytes 4 . putNative) x
+    mapM_ (toBytes 4 . putValue V3) x
 putValue V2 (CqlList x)        = toBytes 4 $ do
     encodeShort (fromIntegral (length x))
     mapM_ (toBytes 2 . putNative) x
 putValue V3 (CqlSet x)         = toBytes 4 $ do
     encodeInt (fromIntegral (length x))
-    mapM_ (toBytes 4 . putNative) x
+    mapM_ (toBytes 4 . putValue V3) x
 putValue V2 (CqlSet x)         = toBytes 4 $ do
     encodeShort (fromIntegral (length x))
     mapM_ (toBytes 2 . putNative) x
 putValue V3 (CqlMap x)         = toBytes 4 $ do
     encodeInt (fromIntegral (length x))
-    forM_ x $ \(k, v) -> toBytes 4 (putNative k) >> toBytes 4 (putNative v)
+    forM_ x $ \(k, v) -> toBytes 4 (putValue V3 k) >> toBytes 4 (putValue V3 v)
 putValue V2 (CqlMap x)         = toBytes 4 $ do
     encodeShort (fromIntegral (length x))
     forM_ x $ \(k, v) -> toBytes 2 (putNative k) >> toBytes 2 (putNative v)


### PR DESCRIPTION
After much nashing of teeth I realized that serializing lists calls putNative which does not support UDTs. I added it to all the V3 collections.

I have verified this with lists but nothing else. It is possible to create combinations that cassandra will not accept.
